### PR TITLE
Initial deployment script testing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  retrieve-secret:
+  terraform-deploy:
     runs-on: ubuntu-latest
 
     permissions:
@@ -125,5 +125,5 @@ jobs:
         run: exit 1
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,12 +15,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve secret from Vault
-        uses: hashicorp/vault-action@v2.4.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           method: jwt
-          url: https://quansight-public-vault-fe415d04.c219cf75.z1.hashicorp.cloud:8200
-          namespace: admin/quansight
-          role: repository-quansight-labs-jupyterlab-user-testing-role
+          url: "https://quansight-public-vault-fe415d04.c219cf75.z1.hashicorp.cloud:8200"
+          namespace: "admin/quansight"
+          role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
             kv/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+            kv/data/repository/Quansight/conda-store/shared_secrets PYPI_USERNAME | PYPI_USERNAME
 
       - name: Use secret from Vault
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,8 +22,15 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets TF_API_TOKEN | TF_API_TOKEN
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github project_id | PROJECT_ID
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github workload_identity_provider | GCP_WORKFLOW_PROVIDER;
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github service_account_name | GCP_SERVICE_ACCOUNT;
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/Internal-devops@quansight.com's Account/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;
 
-      - name: Use secret from Vault
-        run: |
-          python -c "import os; print(os.environ['PYPI_USERNAME'])"
+      - name: 'Authenticate to GCP'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          create_credentials_file: 'true'
+          workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3
@@ -43,28 +44,54 @@ jobs:
           terraform_version: "1.3.7"
           cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
 
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
       - name: Terraform Init
         id: init
         run: terraform init
 
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
       - name: Terraform Plan
         id: plan
-        if: github.event_name == 'pull_request'
         run: terraform plan -no-color
         continue-on-error: true
 
-      - name: Update Pull Request
-        uses: actions/github-script@0.9.0
+      - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+            })
+
+            // 2. Prepare format of the comment
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            <details><summary>Validation Output</summary>
+
+            \`\`\`\n
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
 
             <details><summary>Show Plan</summary>
 
@@ -74,14 +101,24 @@ jobs:
 
             </details>
 
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
 
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
+            // 3. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }
 
       - name: Terraform Plan Status
         if: steps.plan.outcome == 'failure'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,6 @@ jobs:
           create_credentials_file: 'true'
           workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
-          audience: "https://iam.googleapis.com/projects/790595132710/locations/global/workloadIdentityPools/quansight-jlab-a11y/providers/github"
 
       - uses: hashicorp/setup-terraform@v2
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github project_id | PROJECT_ID;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github workload_identity_provider | GCP_WORKFLOW_PROVIDER;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github service_account_name | GCP_SERVICE_ACCOUNT;
-            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/Internal-devops@quansight.com's\ Account/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/internal-devops@quansight.com/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;
 
       - name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,8 +32,7 @@ jobs:
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github service_account_name | GCP_SERVICE_ACCOUNT;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/internal-devops@quansight.com/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;
 
-      - id: auth
-        name: 'Authenticate to GCP'
+      - name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'
         with:
           create_credentials_file: 'true'
@@ -62,8 +61,6 @@ jobs:
         id: plan
         run: terraform plan -no-color
         continue-on-error: true
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
 
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
@@ -130,5 +127,3 @@ jobs:
       - name: Terraform Apply
         # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,6 +39,7 @@ jobs:
           create_credentials_file: 'true'
           workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          audience: "https://iam.googleapis.com/projects/790595132710/locations/global/workloadIdentityPools/quansight-jlab-a11y/providers/github"
 
       - uses: hashicorp/setup-terraform@v2
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,8 @@ jobs:
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github service_account_name | GCP_SERVICE_ACCOUNT;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/internal-devops@quansight.com/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;
 
-      - name: 'Authenticate to GCP'
+      - id: auth
+        name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'
         with:
           create_credentials_file: 'true'
@@ -61,6 +62,8 @@ jobs:
         id: plan
         run: terraform plan -no-color
         continue-on-error: true
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
 
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
@@ -127,3 +130,5 @@ jobs:
       - name: Terraform Apply
         # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,10 @@
 name: deploy
 
 on:
-  push
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   retrieve-secret:
@@ -34,3 +37,56 @@ jobs:
           create_credentials_file: 'true'
           workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "1.3.7"
+          cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      - name: Update Pull Request
+        uses: actions/github-script@0.9.0
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`\n
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'
         with:
+          token_format: access_token
           create_credentials_file: 'true'
           workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github project_id | PROJECT_ID;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github workload_identity_provider | GCP_WORKFLOW_PROVIDER;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github service_account_name | GCP_SERVICE_ACCOUNT;
-            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/Internal-devops@quansight.com's Account/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;
+            "kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/Internal-devops@quansight.com's Account/github-quansight-jupyterlab-accesibility-tljh" token | CLOUDFLARE_API_TOKEN;
 
       - name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github project_id | PROJECT_ID;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github workload_identity_provider | GCP_WORKFLOW_PROVIDER;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github service_account_name | GCP_SERVICE_ACCOUNT;
-            "kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/Internal-devops@quansight.com's Account/github-quansight-jupyterlab-accesibility-tljh" token | CLOUDFLARE_API_TOKEN;
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/Internal-devops@quansight.com's\ Account/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;
 
       - name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -126,5 +126,5 @@ jobs:
         run: exit 1
 
       - name: Terraform Apply
-        # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,29 @@
+name: deploy
+
+on:
+  push
+
+jobs:
+  retrieve-secret:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Retrieve secret from Vault
+        uses: hashicorp/vault-action@v2.4.0
+        with:
+          method: jwt
+          url: https://quansight-public-vault-fe415d04.c219cf75.z1.hashicorp.cloud:8200
+          namespace: admin/quansight
+          role: repository-quansight-labs-jupyterlab-user-testing-role
+          secrets: |
+            kv/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+
+      - name: Use secret from Vault
+        run: |
+          python -c "import os; print(os.environ['PYPI_USERNAME'])"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+            repository/data/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
 
       - name: Use secret from Vault
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,9 +35,9 @@ jobs:
       - name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'
         with:
-          # token_format: access_token
+          token_format: access_token
           create_credentials_file: 'true'
-          workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}a
+          workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
 
       - name: Use secret from Vault
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v1'
         with:
-          token_format: access_token
+          # token_format: access_token
           create_credentials_file: 'true'
           workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           # token_format: access_token
           create_credentials_file: 'true'
-          workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}
+          workload_identity_provider: ${{ env.GCP_WORKFLOW_PROVIDER }}a
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: deploy
+name: Deploy TLJH on GCP
 
 on:
   push:
@@ -10,6 +10,9 @@ jobs:
   terraform-deploy:
     runs-on: ubuntu-latest
 
+    # Ensuring the GITHUB_TOKEN has needed permissions
+    # see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    # and ability to comment on PRs
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            kv/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+            repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
 
       - name: Use secret from Vault
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,8 +22,8 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets TF_API_TOKEN | TF_API_TOKEN
-            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github project_id | PROJECT_ID
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets TF_API_TOKEN | TF_API_TOKEN;
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github project_id | PROJECT_ID;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github workload_identity_provider | GCP_WORKFLOW_PROVIDER;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/google_cloud_platform/quansight-jlab-a11y/github service_account_name | GCP_SERVICE_ACCOUNT;
             kv/data/repository/Quansight-Labs/JupyterLab-user-testing/cloudflare/Internal-devops@quansight.com's Account/github-quansight-jupyterlab-accesibility-tljh token | CLOUDFLARE_API_TOKEN;

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            kv/data/repository/Quansight/conda-store/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
 
       - name: Use secret from Vault
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
           namespace: "admin/quansight"
           role: "repository-quansight-labs-jupyterlab-user-testing-role"
           secrets: |
-            repository/data/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
+            kv/data/repository/Quansight-Labs/JupyterLab-user-testing/shared_secrets PYPI_USERNAME | PYPI_USERNAME
 
       - name: Use secret from Vault
         run: |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # JupyterLab-user-testing
 Repository containing infrastructure and testing scripts for JupyterLab user testing ✨
+
+## TLJH
+
+Access via `https://jupyter-a11y.quansight.dev`

--- a/README.md
+++ b/README.md
@@ -4,3 +4,43 @@ Repository containing infrastructure and testing scripts for JupyterLab user tes
 ## TLJH
 
 Access via `https://jupyter-a11y.quansight.dev`
+
+### Requirements
+
+ - Terraform
+ - Google Cloud Platform account
+ - Cloudflare account
+
+While this github actions gets credentials via OIDC your method of
+authentication will be different. 
+
+See the following for getting credentials:
+ - [How to get credentials for GCP](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started)
+ - [How to get credentials for Cloudflare](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
+
+### Deployment
+
+Currently all infrastructure is deployed via Terraform to Google Cloud
+Platform. We deploy an `Ubuntu 22.02 LTS` VM of size `e2-standard-2`
+(2 CPU and 8 GB RAM) in the `us-central1-a` region/zone. We use
+Cloudflare to point a Quansight owned DNS domain to the GCP
+server. When a pull request is opened a `terraform plan` step is run
+which checks what resources will be created/destroyed/or updated. On
+push to `main` resources are applied via `terraform apply`.
+
+Additional steps since it is hard to fully automate TLJH in terraform:
+
+0. [Visit vm gcp page and ssh into instance](https://console.cloud.google.com/compute/instances)
+1. `curl -L https://tljh.jupyter.org/bootstrap.py | sudo -E python3 - --admin <admin-user-name>`
+2. `sudo tljh-config set https.enabled true`
+3. `sudo tljh-config set https.letsencrypt.email <your-email>`
+4. `sudo tljh-config add-item https.letsencrypt.domains <your-domain>`
+5. `sudo tljh-config reload proxy`
+6. `sudo tljh-config set user_environment.default_app jupyterlab`
+7. `sudo tljh-config reload hub`
+8. `sudo -E conda install -c conda-forge numpy pandas scipy`
+9. login to domain with `https://<your-domain>` with username `<admin-user-name>` and set initial password
+
+
+
+

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance" "main" {
 
   boot_disk {
     initialize_params {
-      image = " ubuntu-2204-jammy-v20230214"
+      image = "ubuntu-2204-lts"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "remote" {
+    organization = "quansight"
+
+    workspaces {
+      name = "github-quansight-labs-jupyterlab-user-testing"
+    }
+  }
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "4.54.0"
+    }
+  }
+}
+
+
+provider "google" {
+}

--- a/main.tf
+++ b/main.tf
@@ -20,8 +20,9 @@ terraform {
   }
 }
 
-
-provider "google" {}
+provider "google" {
+  region = "us-central1"
+}
 
 provider "cloudflare" {}
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ provider "google" {}
 
 resource "google_compute_firewall" "allow-http" {
   name    = "http-firewall"
-  network = google_compute_network.default.name
+  network = "default"
 
   source_ranges = ["0.0.0.0/0"]
 
@@ -30,10 +30,6 @@ resource "google_compute_firewall" "allow-http" {
   }
 
   source_tags = ["web"]
-}
-
-resource "google_compute_network" "default" {
-  name = "test-network"
 }
 
 resource "google_compute_instance" "default" {
@@ -46,9 +42,6 @@ resource "google_compute_instance" "default" {
   boot_disk {
     initialize_params {
       image = " ubuntu-2204-jammy-v20230214"
-      labels = {
-        my_label = "value"
-      }
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "4.54.0"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -18,14 +18,30 @@ terraform {
 
 provider "google" {}
 
+resource "google_compute_firewall" "allow-http" {
+  name    = "http-firewall"
+  network = google_compute_network.default.name
 
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_tags = ["web"]
+}
+
+resource "google_compute_network" "default" {
+  name = "test-network"
+}
 
 resource "google_compute_instance" "default" {
   name         = "jupyterlab-a11y-testing"
   machine_type = "e2-standard-2"
   zone         = "us-central1-a"
 
-  tags = ["foo", "bar"]
+  tags = ["web"]
 
   boot_disk {
     initialize_params {

--- a/main.tf
+++ b/main.tf
@@ -64,10 +64,6 @@ resource "google_compute_instance" "main" {
       nat_ip = google_compute_address.static.address
     }
   }
-
-  metadata = {
-    foo = "bar"
-  }
 }
 
 data "cloudflare_zone" "main" {
@@ -81,13 +77,3 @@ resource "cloudflare_record" "main" {
   type    = "A"
   proxied = false
 }
-
-
-# follow tljh installation instructions
-# 0. visit vm gcp page and ssh into instance
-# 1. curl -L https://tljh.jupyter.org/bootstrap.py | sudo -E python3 - --admin <admin-user-name>
-# 2. sudo tljh-config set https.enabled true
-# 3. sudo tljh-config set https.letsencrypt.email costrouchov@quansight.com
-# 4. sudo tljh-config add-item https.letsencrypt.domains jupyter-a11y.quansight.dev
-# 5. sudo tljh-config reload proxy
-# 6. login to domain with jupyter-a11y.quansight.dev and set initial password

--- a/main.tf
+++ b/main.tf
@@ -68,8 +68,6 @@ resource "google_compute_instance" "main" {
   metadata = {
     foo = "bar"
   }
-
-  metadata_startup_script = "curl -L https://tljh.jupyter.org/bootstrap.py | sudo python3 - --admin costrouc"
 }
 
 data "cloudflare_zone" "main" {
@@ -83,3 +81,13 @@ resource "cloudflare_record" "main" {
   type    = "A"
   proxied = false
 }
+
+
+# follow tljh installation instructions
+# 0. visit vm gcp page and ssh into instance
+# 1. curl -L https://tljh.jupyter.org/bootstrap.py | sudo -E python3 - --admin <admin-user-name>
+# 2. sudo tljh-config set https.enabled true
+# 3. sudo tljh-config set https.letsencrypt.email costrouchov@quansight.com
+# 4. sudo tljh-config add-item https.letsencrypt.domains jupyter-a11y.quansight.dev
+# 5. sudo tljh-config reload proxy
+# 6. login to domain with jupyter-a11y.quansight.dev and set initial password

--- a/main.tf
+++ b/main.tf
@@ -12,13 +12,20 @@ terraform {
       source  = "hashicorp/google"
       version = "4.54.0"
     }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
   }
 }
 
 
 provider "google" {}
 
-resource "google_compute_firewall" "allow-http" {
+provider "cloudflare" {}
+
+resource "google_compute_firewall" "main" {
   name    = "http-firewall"
   network = "default"
 
@@ -32,7 +39,11 @@ resource "google_compute_firewall" "allow-http" {
   source_tags = ["web"]
 }
 
-resource "google_compute_instance" "default" {
+resource "google_compute_address" "static" {
+  name = "ipv4-address"
+}
+
+resource "google_compute_instance" "main" {
   name         = "jupyterlab-a11y-testing"
   machine_type = "e2-standard-2"
   zone         = "us-central1-a"
@@ -49,7 +60,7 @@ resource "google_compute_instance" "default" {
     network = "default"
 
     access_config {
-      // Ephemeral public IP
+      nat_ip = google_compute_address.static.address
     }
   }
 
@@ -58,4 +69,16 @@ resource "google_compute_instance" "default" {
   }
 
   metadata_startup_script = "curl -L https://tljh.jupyter.org/bootstrap.py | sudo python3 - --admin costrouc"
+}
+
+data "cloudflare_zone" "main" {
+  name = "quansight.dev"
+}
+
+resource "cloudflare_record" "main" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "jupyter-a11y"
+  value   = google_compute_address.static.address
+  type    = "A"
+  proxied = false
 }

--- a/main.tf
+++ b/main.tf
@@ -16,5 +16,37 @@ terraform {
 }
 
 
-provider "google" {
+provider "google" {}
+
+
+
+resource "google_compute_instance" "default" {
+  name         = "jupyterlab-a11y-testing"
+  machine_type = "e2-standard-2"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = " ubuntu-2204-jammy-v20230214"
+      labels = {
+        my_label = "value"
+      }
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  metadata_startup_script = "curl -L https://tljh.jupyter.org/bootstrap.py | sudo python3 - --admin costrouc"
 }


### PR DESCRIPTION
This does not entirely close https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/192 since documentation and customization is still needed.

This deploys (has already deployed) a running tljh installation with Quansight's credentials at `jupyter-a11y.quansight.dev`.  