### PR TITLE
Trigger a redeploy of VM when requirements.txt changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ resource "google_compute_instance" "main" {
   }
 
   metadata_startup_script = <<EOT
+echo "requirements.txt sha256=${filesha256("./requirements.txt")} (trigger redeploy)"
 curl -L https://tljh.jupyter.org/bootstrap.py | sudo python3 - --admin ${var.admin-username} --user-requirements-txt-url https://raw.githubusercontent.com/Quansight-Labs/JupyterLab-user-testing/main/requirements.txt
 sudo tljh-config set https.enabled true
 sudo tljh-config set https.letsencrypt.email ${var.letsencrypt-email}


### PR DESCRIPTION
This is a small hack (similar approaches used for kubernetes resources in helm charts). This will change the text of the script when the requirements.txt file changes trigger a redeployment of the VM since `metadata_startup_script` has changed.